### PR TITLE
Use jq to get only secret data in JSON mode

### DIFF
--- a/.buildkite/scripts/test-json-path-depth-1.sh
+++ b/.buildkite/scripts/test-json-path-depth-1.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-EXPECTED_MESSAGE='"message": "Hello from Vault"'
+EXPECTED_MESSAGE='{"message":"Hello from Vault"}'
 
 if [ -z "$TEST_SECRET" ]; then
   echo "[ERROR] TEST_SECRET variable is empty or not defined."
   exit 1
 fi
 
-is_expected_message=$(echo "$TEST_SECRET" | grep -c "$EXPECTED_MESSAGE")
-
-if [ "$is_expected_message" -eq 1 ]; then
+if [ "$TEST_SECRET" == "$EXPECTED_MESSAGE" ]; then
   echo "TEST_SECRET is correct: $TEST_SECRET"
   exit 0
 else

--- a/.buildkite/scripts/test-json-path-depth-3.sh
+++ b/.buildkite/scripts/test-json-path-depth-3.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-EXPECTED_MESSAGE='"message": "Hello from Vault"'
+EXPECTED_MESSAGE='{"message":"Hello from Vault"}'
 
 if [ -z "$CI_ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET" ]; then
   echo "[ERROR] CI_ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET variable is empty or not defined."
   exit 1
 fi
 
-is_expected_message=$(echo "$CI_ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET" | grep -c "$EXPECTED_MESSAGE")
-
-if [ "$is_expected_message" -eq 1 ]; then
+if [ "$CI_ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET" == "$EXPECTED_MESSAGE" ]; then
   echo "CI_ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET is correct: $CI_ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET"
   exit 0
 else

--- a/.buildkite/scripts/test-json-var-mapping.sh
+++ b/.buildkite/scripts/test-json-var-mapping.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-EXPECTED_MESSAGE='"message": "Hello from Vault"'
+EXPECTED_MESSAGE='{"message":"Hello from Vault"}'
 
 if [ -z "$MESSAGE" ]; then
   echo "[ERROR] MESSAGE variable is empty or not defined."
   exit 1
 fi
 
-is_expected_message=$(echo "$MESSAGE" | grep -c "$EXPECTED_MESSAGE")
-
-if [ "$is_expected_message" -eq 1 ]; then
+if [ "$MESSAGE" == "$EXPECTED_MESSAGE" ]; then
   echo "MESSAGE is correct: $MESSAGE"
   exit 0
 else

--- a/.buildkite/scripts/test-json.sh
+++ b/.buildkite/scripts/test-json.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-EXPECTED_MESSAGE='"message": "Hello from Vault"'
+EXPECTED_MESSAGE='{"message":"Hello from Vault"}'
 
 if [ -z "$ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET" ]; then
   echo "[ERROR] ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET variable is empty or not defined."
   exit 1
 fi
 
-is_expected_message=$(echo "$ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET" | grep -c "$EXPECTED_MESSAGE")
-
-if [ "$is_expected_message" -eq 1 ]; then
+if [ "$ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET" == "$EXPECTED_MESSAGE" ]; then
   echo "ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET is correct: $ELASTIC_VAULT_SECRETS_BUILDKITE_PLUGIN_TEST_SECRET"
   exit 0
 else

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple buildkite plugin to map a Vault secret to a Step environment variable
 
+## Requirements
+
+`vault` and `jq` are expected to be installed on your Buildkite worker.
+
 ## Usage
 
 Add the following to your `pipeline.yml`:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: "<your-command>"
     plugins:
-      - elastic/vault-secrets#v0.0.1:
+      - elastic/vault-secrets#v0.0.2:
           path: "secret/ci/elastic-<repo-name>/<secret-name>"
           field: "<secret-field-name>" # OPTIONAL
           env_var: "<environment-variable-mapping-secret>" # OPTIONAL

--- a/hooks/environment
+++ b/hooks/environment
@@ -63,7 +63,8 @@ secret=""
 if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_FIELD}" ]; then
   secret=$(retry vault kv get -field="${BUILDKITE_PLUGIN_VAULT_SECRETS_FIELD}" "${BUILDKITE_PLUGIN_VAULT_SECRETS_PATH}")
 else
-  secret=$(retry vault kv get -format=json "${BUILDKITE_PLUGIN_VAULT_SECRETS_PATH}")
+  check_command jq
+  secret=$(retry vault kv get -format=json "${BUILDKITE_PLUGIN_VAULT_SECRETS_PATH}" | jq -c .data)
 fi
 
 if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_ENV_VAR}" ]; then


### PR DESCRIPTION
This commit is using `jq` to retrieve only the secret data in JSON mode.

`jq` also makes the JSON data single-line to ensure it is redacted correctly using [Buildkite redacted environment variables](https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables) as multi-lines variables aren't supported in some version of the Buildkite agent.