### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -38,8 +38,12 @@ spec:
       repository: elastic/vault-secrets-buildkite-plugin
       create: false
       teams:
+        continuous-integration:
+          role: Admin
         release-eng:
           role: Admin
+        employees:
+          role: Read
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
Update the catalog-info to match [this](https://github.com/elastic/catalog-info/blob/ad608364076f9118c09f1aa9d30f113434f0d5c5/resources/github/elastic-vault-secrets-buildkite-plugin.yaml)


Context: This repo definition is also stored in the [catalog-info repo](https://github.com/elastic/catalog-info/blob/ad608364076f9118c09f1aa9d30f113434f0d5c5/resources/github/elastic-vault-secrets-buildkite-plugin.yaml) so terrazzo is currently ignoring the definition in the `vault-secrets-buildkite-plugin` repo. Moving forward, we prefer that catalog information is stored as close to the src repo as possible so as soon as this PR is submitted (or dropped, if applicable), I will go ahead and remove the file from the catalog-info repo.