### PR TITLE
Add buildkite secret redaction

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -12,6 +12,25 @@ check_command() {
   fi
 }
 
+# In `buildkite-agent` 3.66.0
+# (https://github.com/buildkite/agent/releases/tag/v3.66.0) the ability to
+# redact secrets (https://buildkite.com/docs/agent/v3/cli-redactor) was added.
+# However, because we may not always run that version of `buildkite-agent`, we
+# should conditionally enable it
+check_buildkite_agent_version_for_redaction() {
+  local version_output
+  version_output="$(buildkite-agent --version)"
+  local version
+  version="$(echo "$version_output" | grep -oP '\d+\.\d+\.\d+')"
+  local min_version="3.66.0"
+  if [[ "$(printf '%s\n%s\n' "$min_version" "$version" | sort --version-sort | head -n1)" = "$min_version" ]]; then
+    return 0
+  else
+    echo "Buildkite agent version $version is less than $min_version. Redactor is not available."
+    return 1
+  fi
+}
+
 generate_variable_name() {
   local path=$1
   local field=$2
@@ -56,7 +75,7 @@ retry() {
 }
 
 check_command vault
-
+check_command buildkite-agent
 BUILDKITE_PLUGIN_VAULT_SECRETS_PATH_DEPTH=${BUILDKITE_PLUGIN_VAULT_SECRETS_PATH_DEPTH:-$DEFAULT_PATH_DEPTH}
 
 secret=""
@@ -65,6 +84,13 @@ if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_FIELD}" ]; then
 else
   check_command jq
   secret=$(retry vault kv get -format=json "${BUILDKITE_PLUGIN_VAULT_SECRETS_PATH}" | jq -c .data)
+fi
+
+set +x
+if check_buildkite_version; then
+  echo "${secret}" | buildkite-agent redactor add
+else
+  echo "Buildkite agent redactor is not available. Skipping redaction."
 fi
 
 if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_ENV_VAR}" ]; then


### PR DESCRIPTION
Use buildkite agent secret redaction to hide secrets from buildkite logs.

### Tests
It was tested in this pipeline:  https://buildkite.com/elastic/vault-secrets-buildkite-plugin/builds/161

Output:
```
Running commands
$ echo '*** this is the variable name: $[REDACTED]'
*** this is the variable name: $[REDACTED]
```

We can see in that the name of the variable appears as `REDACTED` in the [logs](https://buildkite.com/elastic/vault-secrets-buildkite-plugin/builds/161#01964349-d43f-41f2-a50f-575957e9e4ca)


