### PR TITLE
Migration: reassign team ownership to @elastic/ci-systems

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @elastic/platform-dev-flow
+*   @elastic/ci-systems

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -17,7 +17,7 @@ metadata:
 
 spec:
   type: buildkite-plugin
-  owner: group:platform-dev-flow
+  owner: group:ci-systems
   lifecycle: beta
 
 ---
@@ -38,7 +38,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:platform-dev-flow
+  owner: group:ci-systems
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -53,6 +53,6 @@ spec:
       teams:
         everyone:
           access_level: BUILD_AND_READ
-        release-eng: {}
-        platform-dev-flow:
+        ci-systems: {}
+        ci-systems:
           access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -53,6 +53,5 @@ spec:
       teams:
         everyone:
           access_level: BUILD_AND_READ
-        ci-systems: {}
         ci-systems:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
Part of the EngProd GitHub team migration (parent: [#2148](https://github.com/elastic/platform-engineering-productivity/issues/2148), this touchpoint: [#2426](https://github.com/elastic/platform-engineering-productivity/issues/2426)).

**⚠️ DO NOT MERGE** until migration day. PRs are merged in batches grouped by new team owner so the [Terrazzo](https://github.com/elastic/terrazzo) wild plan for each batch can be reviewed and approved independently.

### Please double-check — classified as `complex`

This repo had multiple changing-team signals (e.g., several old admins, or `catalog-info.yaml` and `catalog.yaml` owners disagree). The mechanical rewrite assigns everything to **@elastic/ci-systems** based on `migration-data.yaml`. Please confirm that's what you want before approving.

### Files changed

- `CODEOWNERS` (1 line)
- `catalog-info.yaml` (4 lines)

---

Generated by `scripts/github-team-migration/open_repo_prs.py`.