### PR TITLE
docs: declare runtime dependencies in plugin.yml requirements (g5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A simple buildkite plugin to map a Vault secret to a Step environment variable
 
 ## Requirements
 
-`vault` and `jq` are expected to be installed on your Buildkite worker.
+`vault` and `buildkite-agent` are expected to be installed on your Buildkite
+worker. `jq` is also required, but only when the `field` property (see
+below) is not set.
 
 ## Usage
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: vault-secrets-buildkite-plugin
-description: A buildkite plugin to map Vault secrets to Step environments variables
+description: A buildkite plugin to map Vault secrets to Step environment variables
 author: https://github.com/jmlrt
 requirements:
   - vault

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,12 @@
 name: vault-secrets-buildkite-plugin
 description: A buildkite plugin to map Vault secrets to Step environments variables
 author: https://github.com/jmlrt
-requirements: []
+requirements:
+  - vault
+  - buildkite-agent
+  # `jq` is also required, but only when the `field` property is not set —
+  # see hooks/environment (the whole secret is fetched as JSON and piped
+  # through `jq` only in that branch).
 configuration:
   properties:
     path:


### PR DESCRIPTION
## What

Populates `plugin.yml`'s previously-empty `requirements: []` field with the plugin's real runtime dependencies, and syncs README.md's "Requirements" section to match.

## Why

This repo's `ai_repo_ready` gate scorecard (`ai_repo_ready/examples/vault-secrets-buildkite-plugin-scorecard.md`, item `g5 dependency_manifest`) flagged that `plugin.yml`'s `requirements` field — exactly where the internal dev guide's template says external binary dependencies belong — was empty, despite `hooks/environment` unconditionally shelling out to `vault` and `buildkite-agent`, and conditionally to `jq`.

Verified directly against `hooks/environment`:
- `vault` and `buildkite-agent` are checked unconditionally via `check_command` (lines 77-78).
- `jq` is only checked/used in the branch where `BUILDKITE_PLUGIN_VAULT_SECRETS_FIELD` is unset (the whole secret is fetched as JSON and piped through `jq`) — when `field` is set, `jq` is never invoked.

Since `jq`'s requirement is conditional and the plugin schema's `requirements` field has no way to express "required only if X", it's listed as a YAML comment next to the two unconditional entries rather than overstated as always-required.

## Note from code-review

A review pass caught that README.md's existing "Requirements" section (`vault` and `jq` are expected to be installed`) omitted `buildkite-agent` entirely and stated `jq` as unconditional — already inaccurate before this PR, and would have become inconsistent with the corrected `plugin.yml` if left alone. Updated it to match.

Cites: `ai_repo_ready/examples/vault-secrets-buildkite-plugin-scorecard.md`, gate item `g5` / `criteria.yaml`'s `dependency_manifest`.