### PR TITLE
docs: add credential-pattern exclusions to .gitignore (g6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
 .hermit
+
+# Credential/secret-shaped files that should never be committed. This
+# plugin fetches secrets from Vault at CI runtime and never persists them
+# to disk by design; these patterns are a safety net against a future
+# contributor accidentally committing a local .env/debug/credential file.
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+*credentials*
+*secret*

--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,20 @@
 # plugin fetches secrets from Vault at CI runtime and never persists them
 # to disk by design; these patterns are a safety net against a future
 # contributor accidentally committing a local .env/debug/credential file.
+#
+# Patterns are intentionally anchored/specific rather than unanchored
+# substrings like `*secret*` or `*credentials*` -- this repo's own name
+# (vault-secrets-buildkite-plugin) and its documented Vault path
+# convention (e.g. `secret/ci/...`) legitimately contain those words, and
+# a bare substring glob would silently exclude real files/directories
+# (e.g. a future `secret/` dir or `CREDENTIALS.md` doc) with no warning.
 .env
 .env.*
 *.pem
 *.key
 *.p12
 *.pfx
-*credentials*
-*secret*
+credentials.json
+credentials.yml
+credentials.yaml
+*.credentials.json


### PR DESCRIPTION
## What

Extends `.gitignore` (currently a single line, `.hermit`) with exclusions for common credential/secret-shaped file patterns.

## Why

This repo's `ai_repo_ready` gate scorecard (`ai_repo_ready/examples/vault-secrets-buildkite-plugin-scorecard.md`, item `g6 no_committed_secrets`) noted that the plugin's actual secret-handling practice is already sound — secrets are fetched from Vault at CI runtime and never persisted to disk, with `set +x` and conditional redactor registration around the value (all verified directly against `hooks/environment`) — but the mechanical safety net that would stop a future contributor from accidentally committing a local `.env`/debug/credential file doesn't exist.

Verified via `git ls-files` + `git check-ignore` that no currently-tracked file is affected by these new patterns.

## Note from code-review

An earlier draft of this PR used unanchored substring globs (`*secret*`, `*credentials*`). A review pass caught that these would silently exclude legitimate files and directories in this specific repo — since it's literally named `vault-secrets-buildkite-plugin` and documents its Vault path convention as `secret/ci/...` — with no warning to a contributor. Verified experimentally that the original patterns would have gitignored `vault-secrets-buildkite-plugin.md`, `CREDENTIALS.md`, a future `secret/` directory, and `docs/credentials-setup.md`.

Replaced with specific, anchored patterns (`credentials.json`, `credentials.yml`, `credentials.yaml`, `*.credentials.json`, plus `.env`/`.env.*`/`*.pem`/`*.key`/`*.p12`/`*.pfx`) that still catch real credential-shaped filenames without matching ordinary project vocabulary. Re-verified both directions: the false-positive scenarios above are no longer ignored, and real credential shapes (`.env`, `.env.production`, `id.pem`, `server.key`, `credentials.json`) are still caught.

Cites: `ai_repo_ready/examples/vault-secrets-buildkite-plugin-scorecard.md`, gate item `g6` / `criteria.yaml`'s `no_committed_secrets`.